### PR TITLE
Resizing TabPane with the JFrame

### DIFF
--- a/ClassySharkWS/src/com/google/classyshark/ui/tabs/TabPanel.java
+++ b/ClassySharkWS/src/com/google/classyshark/ui/tabs/TabPanel.java
@@ -60,6 +60,7 @@ public class TabPanel extends JPanel implements KeyListener {
     public TabPanel(JTabbedPane tabbedPane, int myIndex) {
         super(false);
 
+        this.setLayout(new BorderLayout());
         this.tabbedPane = tabbedPane;
         this.myIndexAtTabbedPane = myIndex;
 
@@ -75,7 +76,7 @@ public class TabPanel extends JPanel implements KeyListener {
         JScrollPane scrollPane = new JScrollPane(displayArea.onAddComponentToPane());
         scrollPane.setPreferredSize(new Dimension(800, 700));
 
-        add(scrollPane, BorderLayout.SOUTH);
+        add(scrollPane, BorderLayout.CENTER);
     }
 
     @Override


### PR DESCRIPTION
The TabPane was not being resized, so
the content was centralized. Resizing
makes it easier to see the content when
lines are large on AndroidManifest.xml
