### PR TITLE
xml parsing errors fix

### DIFF
--- a/ClassySharkWS/src/com/google/classyshark/silverghost/translator/xml/XmlDecompressor.java
+++ b/ClassySharkWS/src/com/google/classyshark/silverghost/translator/xml/XmlDecompressor.java
@@ -295,7 +295,7 @@ public class XmlDecompressor {
                     attributeValue = String.format("0x%08X", attributeResourceId);
 
             }
-            sb.append(attributeName).append("='").append(attributeValue).append("'");
+            sb.append(attributeName).append("=\"").append(attributeValue).append("\"");
         }
     }
 


### PR DESCRIPTION
 When there is nesting ' in string, it can cause XML parsing errors